### PR TITLE
Configurable reset level. Skip functionality. Disable functionality. Login level check.

### DIFF
--- a/conf/mod_player_bot_reset.conf.dist
+++ b/conf/mod_player_bot_reset.conf.dist
@@ -61,8 +61,9 @@ ResetBotLevel.MinTimePlayed = 86400
 #    ResetBotLevel.PlayedTimeCheckFrequency
 #        Description: If enabled (ResetBotLevel.RestrictTimePlayed) The frequency (in seconds) at which the time played check is
 #                     performed for bots at or above the maximum level.
-#        Default:     300
-ResetBotLevel.PlayedTimeCheckFrequency = 300
+#        Default:     864
+#        Recommended range: 1% of MinTimePlayed or 300 seconds, whichever is higher.
+ResetBotLevel.PlayedTimeCheckFrequency = 864
 
 #    ResetBotLevel.DebugMode
 #        Description: Enables debug logging for the Reset Bot Level module.

--- a/conf/mod_player_bot_reset.conf.dist
+++ b/conf/mod_player_bot_reset.conf.dist
@@ -5,15 +5,34 @@
 ########################################
 #
 #    ResetBotLevel.MaxLevel
-#        Description: The maximum level a bot can reach before being reset to level 1.
+#        Description: The maximum level a bot can reach before being reset.
 #        Default:     80 
-#                     Valid range: 2-80
-ResetBotLevel.MaxLevel   = 80
+#        Valid range: 2-80 (or 0 to disable)
+ResetBotLevel.MaxLevel = 80
+
+#    ResetBotLevel.ResetToLevel
+#        Description: The level bots will be reset to. For Death Knights, if this is below 55, they will be reset to 55 instead.
+#        Default:     1
+#        Valid range: 1-79 and < MaxLevel
+ResetBotLevel.ResetToLevel = 1
+
+#    ResetBotLevel.SkipFromLevel
+#        Description: When a bot reaches exactly this level, they will be sent directly to the level specified by SkipToLevel.
+#                     This setting is not affected by ScaledChance or RestrictTimePlayed.
+#        Default:     0 (disabled)
+#        Valid range: 1-80 and < MaxLevel (or 0 to disable)
+ResetBotLevel.SkipFromLevel = 0
+
+#    ResetBotLevel.SkipToLevel
+#        Description: The level bots will be sent to when they reach SkipFromLevel. For Death Knights, if this is below 55, they will be reset to 55 instead.
+#        Default:     1
+#        Valid range: 1-80 and <= MaxLevel
+ResetBotLevel.SkipToLevel = 1
 
 #    ResetBotLevel.ResetChance
 #        Description: The percent chance a bot has to have their level reset back to 1 when reaching the max specified level or time played.
 #        Default:     100 
-#                     Valid range: 0-100
+#        Valid range: 0-100
 ResetBotLevel.ResetChance = 100
 
 #    ResetBotLevel.ScaledChance
@@ -23,31 +42,31 @@ ResetBotLevel.ResetChance = 100
 #                     as they approach the max level. At the max level, the reset chance reaches
 #                     the configured ResetBotLevel.ResetChance value.
 #        Default:     0 (disabled)
-#                     Valid values: 0 (off) / 1 (on)
+#        Valid values: 0 (off) / 1 (on)
 ResetBotLevel.ScaledChance = 0
 
 #    ResetBotLevel.RestrictTimePlayed
 #        Description: If enabled (1), bots will only have their level reset if they have played
 #                     at least the configured minimum time at the current level when at max level.
 #        Default:     0 (disabled)
-#                     Valid values: 0 (off) / 1 (on)
+#        Valid values: 0 (off) / 1 (on)
 ResetBotLevel.RestrictTimePlayed = 0
 
 #    ResetBotLevel.MinTimePlayed
 #        Description: If enabled (ResetBotLevel.RestrictTimePlayed) The minimum time (in seconds) that a bot must have
 #                     played at its current level before a reset can occur when at max level.
-#        Default:     86400 - 1 Day
+#        Default:     86400 (3600 = 1 hour, 86400 = 1 day, 604800 = 1 week)
 ResetBotLevel.MinTimePlayed = 86400
 
 #    ResetBotLevel.PlayedTimeCheckFrequency
 #        Description: If enabled (ResetBotLevel.RestrictTimePlayed) The frequency (in seconds) at which the time played check is
 #                     performed for bots at or above the maximum level.
-#        Default:     60
-ResetBotLevel.PlayedTimeCheckFrequency = 60
+#        Default:     300
+ResetBotLevel.PlayedTimeCheckFrequency = 300
 
 #    ResetBotLevel.DebugMode
 #        Description: Enables debug logging for the Reset Bot Level module.
 #                     When enabled, additional log information is displayed to help with debugging.
 #        Default:     0 (disabled)
-#                     Valid values: 0 (off) / 1 (on)
+#        Valid values: 0 (off) / 1 (on)
 ResetBotLevel.DebugMode = 0

--- a/src/mod-player-bot-reset.cpp
+++ b/src/mod-player-bot-reset.cpp
@@ -30,8 +30,8 @@ static const uint32 PERIODIC_CHECK_INTERVAL = 15 * 60 * 1000; // in milliseconds
 
 // When true, bots at or above g_ResetBotMaxLevel are reset only after they have
 // accumulated at least g_MinTimePlayed seconds at that level.
-static bool  g_RestrictResetByPlayedTime = false;
-static uint32 g_MinTimePlayed             = 86400; // in seconds (1 Day)
+static bool  g_RestrictResetByPlayedTime  = false;
+static uint32 g_MinTimePlayed             = 86400;  // in seconds (1 Day)
 static uint32 g_PlayedTimeCheckFrequency  = 300;    // in seconds (default check frequency)
 
 // -----------------------------------------------------------------------------

--- a/src/mod-player-bot-reset.cpp
+++ b/src/mod-player-bot-reset.cpp
@@ -28,7 +28,6 @@ static bool  g_DebugMode             = false;
 static bool  g_ScaledChance          = false;
 static const uint32 PERIODIC_CHECK_INTERVAL = 15 * 60 * 1000; // in milliseconds (15 minutes)
 
-
 // When true, bots at or above g_ResetBotMaxLevel are reset only after they have
 // accumulated at least g_MinTimePlayed seconds at that level.
 static bool  g_RestrictResetByPlayedTime = false;

--- a/src/mod-player-bot-reset.cpp
+++ b/src/mod-player-bot-reset.cpp
@@ -32,7 +32,7 @@ static const uint32 PERIODIC_CHECK_INTERVAL = 15 * 60 * 1000; // in milliseconds
 // accumulated at least g_MinTimePlayed seconds at that level.
 static bool  g_RestrictResetByPlayedTime  = false;
 static uint32 g_MinTimePlayed             = 86400;  // in seconds (1 Day)
-static uint32 g_PlayedTimeCheckFrequency  = 300;    // in seconds (default check frequency)
+static uint32 g_PlayedTimeCheckFrequency  = 864;    // in seconds (default check frequency)
 
 // -----------------------------------------------------------------------------
 // LOAD CONFIGURATION USING sConfigMgr

--- a/src/mod-player-bot-reset.cpp
+++ b/src/mod-player-bot-reset.cpp
@@ -20,15 +20,20 @@
 // GLOBALS: Configuration Values
 // -----------------------------------------------------------------------------
 static uint8 g_ResetBotMaxLevel      = 80;
+static uint8 g_ResetToLevel          = 1;
+static uint8 g_SkipFromLevel         = 0;
+static uint8 g_SkipToLevel           = 1;
 static uint8 g_ResetBotChancePercent = 100;
 static bool  g_DebugMode             = false;
 static bool  g_ScaledChance          = false;
+static bool m_startupCheckDone       = false;
+static const uint32 STARTUP_CHECK_DELAY = 60 * 1000; // in milliseconds (60 seconds)
 
 // When true, bots at or above g_ResetBotMaxLevel are reset only after they have
 // accumulated at least g_MinTimePlayed seconds at that level.
 static bool  g_RestrictResetByPlayedTime = false;
 static uint32 g_MinTimePlayed             = 86400; // in seconds (1 Day)
-static uint32 g_PlayedTimeCheckFrequency  = 60;    // in seconds (default check frequency)
+static uint32 g_PlayedTimeCheckFrequency  = 300;    // in seconds (default check frequency)
 
 // -----------------------------------------------------------------------------
 // LOAD CONFIGURATION USING sConfigMgr
@@ -36,10 +41,31 @@ static uint32 g_PlayedTimeCheckFrequency  = 60;    // in seconds (default check 
 static void LoadPlayerBotResetConfig()
 {
     g_ResetBotMaxLevel = static_cast<uint8>(sConfigMgr->GetOption<uint32>("ResetBotLevel.MaxLevel", 80));
-    if (g_ResetBotMaxLevel < 2 || g_ResetBotMaxLevel > 80)
+    if ((g_ResetBotMaxLevel < 2 || g_ResetBotMaxLevel > 80) && g_ResetBotMaxLevel != 0)
     {
         LOG_ERROR("server.loading", "[mod-player-bot-reset] Invalid ResetBotLevel.MaxLevel value: {}. Using default value 80.", g_ResetBotMaxLevel);
         g_ResetBotMaxLevel = 80;
+    }
+    
+    g_ResetToLevel = static_cast<uint8>(sConfigMgr->GetOption<uint32>("ResetBotLevel.ResetToLevel", 1));
+    if (g_ResetToLevel < 1 || (g_ResetBotMaxLevel > 0 && g_ResetToLevel >= g_ResetBotMaxLevel))
+    {
+        LOG_ERROR("server.loading", "[mod-player-bot-reset] Invalid ResetBotLevel.ResetToLevel value: {}. Using default value 1.", g_ResetToLevel);
+        g_ResetToLevel = 1;
+    }
+    
+    g_SkipFromLevel = static_cast<uint8>(sConfigMgr->GetOption<uint32>("ResetBotLevel.SkipFromLevel", 0));
+    if (g_SkipFromLevel > 80 || (g_ResetBotMaxLevel > 0 && g_SkipFromLevel >= g_ResetBotMaxLevel))
+    {
+        LOG_ERROR("server.loading", "[mod-player-bot-reset] Invalid ResetBotLevel.SkipFromLevel value: {}. Using default value 0 (disabled).", g_SkipFromLevel);
+        g_SkipFromLevel = 0;
+    }
+    
+    g_SkipToLevel = static_cast<uint8>(sConfigMgr->GetOption<uint32>("ResetBotLevel.SkipToLevel", 1));
+    if (g_SkipToLevel < 1 || g_SkipToLevel > 80 || (g_ResetBotMaxLevel > 0 && g_SkipToLevel > g_ResetBotMaxLevel))
+    {
+        LOG_ERROR("server.loading", "[mod-player-bot-reset] Invalid ResetBotLevel.SkipToLevel value: {}. Using default value 1.", g_SkipToLevel);
+        g_SkipToLevel = 1;
     }
 
     g_ResetBotChancePercent = static_cast<uint8>(sConfigMgr->GetOption<uint32>("ResetBotLevel.ResetChance", 100));
@@ -108,12 +134,14 @@ static uint8 ComputeResetChance(uint8 level)
 // -----------------------------------------------------------------------------
 static void ResetBot(Player* player, uint8 currentLevel)
 {
-    uint8 levelToResetTo = 1;
-    if (player->getClass() == CLASS_DEATH_KNIGHT)
+    uint8 levelToResetTo = g_ResetToLevel;
+    
+    // If the configured reset level is below 55 and this is a Death Knight, use 55 instead
+    if (player->getClass() == CLASS_DEATH_KNIGHT && g_ResetToLevel < 55)
         levelToResetTo = 55;
-
+    
     PlayerbotFactory newFactory(player, levelToResetTo);
-
+    
     newFactory.Randomize(false);
 
     if (g_DebugMode)
@@ -126,6 +154,31 @@ static void ResetBot(Player* player, uint8 currentLevel)
 
     ChatHandler(player->GetSession()).SendSysMessage("[mod-player-bot-reset] Your level has been reset.");
 
+}
+
+// -----------------------------------------------------------------------------
+// HELPER FUNCTION: Perform the Skip Actions for a Bot
+// -----------------------------------------------------------------------------
+static void SkipBotLevel(Player* player, uint8 currentLevel)
+{
+    uint8 levelToSkipTo = g_SkipToLevel;
+    
+    // If the configured skip level is below 55 and this is a Death Knight, use 55 instead
+    if (player->getClass() == CLASS_DEATH_KNIGHT && g_SkipToLevel < 55)
+        levelToSkipTo = 55;
+    
+    PlayerbotFactory newFactory(player, levelToSkipTo);
+    newFactory.Randomize(false);
+
+    if (g_DebugMode)
+    {
+        PlayerbotAI* botAI = sPlayerbotsMgr->GetPlayerbotAI(player);
+        std::string playerClassName = botAI ? botAI->GetChatHelper()->FormatClass(player->getClass()) : "Unknown";
+        LOG_INFO("server.loading", "[mod-player-bot-reset] SkipBotLevel: Bot '{}' - {} at level {} was skipped to level {}.",
+                 player->GetName(), playerClassName, currentLevel, levelToSkipTo);
+    }
+
+    ChatHandler(player->GetSession()).SendSysMessage("[mod-player-bot-reset] Your level has been adjusted.");
 }
 
 // -----------------------------------------------------------------------------
@@ -150,29 +203,43 @@ public:
             LOG_ERROR("server.loading", "[mod-player-bot-reset] OnLevelChanged called with nullptr player.");
             return;
         }
-
+    
         uint8 newLevel = player->GetLevel();
         if (newLevel == 1)
             return;
-
+    
         // Special case for Death Knights.
         if (newLevel == 55 && player->getClass() == CLASS_DEATH_KNIGHT)
             return;
-
+    
         if (!IsPlayerBot(player))
         {
             if (g_DebugMode)
                 LOG_INFO("server.loading", "[mod-player-bot-reset] OnLevelChanged: Player '{}' is not a bot. Skipping reset check.", player->GetName());
             return;
         }
-
+    
         if (!IsPlayerRandomBot(player))
         {
             if (g_DebugMode)
                 LOG_INFO("server.loading", "[mod-player-bot-reset] OnLevelChanged: Player '{}' is not a random bot. Skipping reset check.", player->GetName());
             return;
         }
-
+        
+        // Check for the SkipFromLevel condition - this takes priority and is not affected by other settings
+        if (g_SkipFromLevel > 0 && newLevel == g_SkipFromLevel)
+        {
+            if (g_DebugMode)
+                LOG_INFO("server.loading", "[mod-player-bot-reset] OnLevelChanged: Bot '{}' reached skip level {}. Skipping to level {}.", 
+                         player->GetName(), newLevel, g_SkipToLevel);
+            SkipBotLevel(player, newLevel);
+            return; // Skip further processing once we've done the level skip
+        }
+    
+        // If MaxLevel is disabled (0), skip the reset logic
+        if (g_ResetBotMaxLevel == 0)
+            return;
+    
         // If time-played restriction is enabled and the bot is at (or above) the max level,
         // defer the reset to the periodic OnUpdate handler.
         if (g_RestrictResetByPlayedTime && newLevel >= g_ResetBotMaxLevel)
@@ -181,7 +248,7 @@ public:
                 LOG_INFO("server.loading", "[mod-player-bot-reset] OnLevelChanged: Bot '{}' at level {} deferred to OnUpdate due to time-played restriction.", player->GetName(), newLevel);
             return;
         }
-
+    
         uint8 resetChance = ComputeResetChance(newLevel);
         if (g_ScaledChance || newLevel >= g_ResetBotMaxLevel)
         {
@@ -204,8 +271,13 @@ public:
     void OnStartup() override
     {
         LoadPlayerBotResetConfig();
-        LOG_INFO("server.loading", "[mod-player-bot-reset] Loaded and active with MaxLevel = {}, ResetChance = {}%, ScaledChance = {}.",
+        LOG_INFO("server.loading", "[mod-player-bot-reset] Loaded and active with MaxLevel = {} ({}), ResetToLevel = {}, SkipFromLevel = {} ({}), SkipToLevel = {}, ResetChance = {}%, ScaledChance = {}.",
                  static_cast<int>(g_ResetBotMaxLevel),
+                 g_ResetBotMaxLevel > 0 ? "Enabled" : "Disabled",
+                 static_cast<int>(g_ResetToLevel),
+                 static_cast<int>(g_SkipFromLevel),
+                 g_SkipFromLevel > 0 ? "Enabled" : "Disabled",
+                 static_cast<int>(g_SkipToLevel),
                  static_cast<int>(g_ResetBotChancePercent),
                  g_ScaledChance ? "Enabled" : "Disabled");
     }
@@ -220,11 +292,25 @@ public:
 class ResetBotLevelTimeCheckWorldScript : public WorldScript
 {
 public:
-    ResetBotLevelTimeCheckWorldScript() : WorldScript("ResetBotLevelTimeCheckWorldScript"), m_timer(0) { }
+    ResetBotLevelTimeCheckWorldScript() : WorldScript("ResetBotLevelTimeCheckWorldScript"), 
+        m_timer(0), m_startupCheckTimer(0) { }
 
     void OnUpdate(uint32 diff) override
     {
-        if (!g_RestrictResetByPlayedTime)
+        // One-time startup check for existing bots
+        if (!m_startupCheckDone)
+        {
+            m_startupCheckTimer += diff;
+            if (m_startupCheckTimer >= STARTUP_CHECK_DELAY)
+            {
+                ProcessExistingBots();
+                m_startupCheckDone = true;
+                LOG_INFO("server.loading", "[mod-player-bot-reset] Completed startup check of existing bots.");
+            }
+        }
+
+        // Skip if time restrictions are disabled or MaxLevel is disabled
+        if (!g_RestrictResetByPlayedTime || g_ResetBotMaxLevel == 0)
             return;
 
         m_timer += diff;
@@ -277,8 +363,63 @@ public:
             }
         }
     }
+
 private:
     uint32 m_timer;
+    uint32 m_startupCheckTimer;
+
+    void ProcessExistingBots()
+    {
+        if (g_DebugMode)
+        {
+            LOG_INFO("server.loading", "[mod-player-bot-reset] Starting check of existing bots for level limits...");
+        }
+
+        auto const& allPlayers = ObjectAccessor::GetPlayers();
+        for (auto const& itr : allPlayers)
+        {
+            Player* candidate = itr.second;
+            if (!candidate || !candidate->IsInWorld())
+                continue;
+            if (!IsPlayerBot(candidate) || !IsPlayerRandomBot(candidate))
+                continue;
+
+            uint8 currentLevel = candidate->GetLevel();
+            
+            // Check for SkipFromLevel condition
+            if (g_SkipFromLevel > 0 && currentLevel == g_SkipFromLevel)
+            {
+                if (g_DebugMode)
+                {
+                    LOG_INFO("server.loading", "[mod-player-bot-reset] ProcessExistingBots: Bot '{}' at level {} matches SkipFromLevel. Applying skip.",
+                             candidate->GetName(), currentLevel);
+                }
+                SkipBotLevel(candidate, currentLevel);
+                continue;
+            }
+            
+            // Check for MaxLevel condition
+            if (g_ResetBotMaxLevel > 0 && currentLevel >= g_ResetBotMaxLevel)
+            {
+                if (g_DebugMode)
+                {
+                    LOG_INFO("server.loading", "[mod-player-bot-reset] ProcessExistingBots: Bot '{}' at level {} is at or above MaxLevel {}.",
+                             candidate->GetName(), currentLevel, g_ResetBotMaxLevel);
+                }
+                
+                uint8 resetChance = ComputeResetChance(currentLevel);
+                if (urand(0, 99) < resetChance)
+                {
+                    if (g_DebugMode)
+                    {
+                        LOG_INFO("server.loading", "[mod-player-bot-reset] ProcessExistingBots: Reset chance check passed for bot '{}'. Resetting bot.", 
+                                 candidate->GetName());
+                    }
+                    ResetBot(candidate, currentLevel);
+                }
+            }
+        }
+    }
 };
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
Following @DustinHendrickson work on [reset pairs](https://github.com/DustinHendrickson/mod-player-bot-reset/pull/7) options, which allows for bots to skip certain levels, I found that however good the idea is, in practice configuration can get confusing.

So instead of letting the user create however many reset pairs, a one and simple skip from/to option is added. This option works in conjunction to the existing reset level, which can also be configured now. So bots can now be reset down to any level, not just 1 (as usual if you choose a reset to level that's <55 and you have Death Knights, DKs will be automatically reset to 55). Both functions can also be disabled by setting them to 0.

For the new skip function, here is how it works and how different it is from the reset function:

| Operation | Reset | Skip |
| --- | --- | --- |
| Bot level change | Down only | Up or down |
| Affected bots | Any bot level that is >= MaxLevel | Any bot level this = SkipFromLevel. Has no effect on bots < or > SkipFromLevel |
| ResetChance & RestrictTimePlayed | Affected by these settings | Not affected by these settings |
| Valid Range | 2-80 (or 0 to disable) | 1-80 and < MaxLevel (or 0 to disable) |
| Default setting | Enabled with 80 to 1 | Disabled |

Example case scenario with reset and skip is if you want bots to reset from 80 to 1/55, and also skip Outland (58 to 70).

Other changes:
1. Created a level check that happens every 15 minutes. Previously bots were level checked only on level change, so if a bot was already at level 80 before enabling the module, then it would remain stuck at 80. Now there's a check that happens every 15 minutes, to check if a bot meets skip or reset conditions. This will catch bots that login as the server starts, and bots that login later.
    - Alternative approach to this problem: Have a check timer for each individual bot, that triggers 60 seconds after the bot logins (a delay to process the login operation itself). Not sure which solution more efficient. While it is a small niche issue, hopefully Dustin or any other better coder than I takes a look at it.

2. Changed PlayedTimeCheckFrequency from 60 seconds to 300. Once a minute might be too much if you are running a server with thousands of bots, so it was changed to once every 5 minutes.